### PR TITLE
Send http headers in all responses

### DIFF
--- a/sleepymongoose/handlers.py
+++ b/sleepymongoose/handlers.py
@@ -157,7 +157,7 @@ class MongoHandler:
         if "server" in args:
             try:
                 uri = args.getvalue('server')
-                info = connection._parse_uri(uri)
+                info = connection.uri_parser.parse_uri(uri)
             except Exception, e:
                 print uri
                 print e


### PR DESCRIPTION
Sending headers in error response too is needed for Control-Access-Allow-Origin.
Implementation overwrite the base "headers_end" method to set headers for all responses.
