### PR TITLE
Make handlers.py work with modern PyMongo

### DIFF
--- a/sleepymongoose/handlers.py
+++ b/sleepymongoose/handlers.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pymongo import connection, Connection, ASCENDING, DESCENDING
-from pymongo.son import SON
+from bson.son import SON
+from pymongo import Connection, ASCENDING, DESCENDING
 from pymongo.errors import ConnectionFailure, ConfigurationError, OperationFailure, AutoReconnect
 from bson import json_util
 
@@ -157,7 +157,6 @@ class MongoHandler:
         if "server" in args:
             try:
                 uri = args.getvalue('server')
-                info = connection._parse_uri(uri)
             except Exception, e:
                 print uri
                 print e


### PR DESCRIPTION
sleepy.mongoose now requires pymongo >= 1.9
