### PR TITLE
added do_OPTIONS, fixed CORS

### DIFF
--- a/sleepymongoose/httpd.py
+++ b/sleepymongoose/httpd.py
@@ -74,6 +74,7 @@ class MongoHTTPRequest(BaseHTTPRequestHandler):
     mongos = []
     response_headers = []
     jsonp_callback = None;
+    allowCORS = False;
 
     def _parse_call(self, uri):
         """ 
@@ -174,6 +175,12 @@ class MongoHTTPRequest(BaseHTTPRequestHandler):
 
         return (uri, args, type)
 
+    def do_OPTIONS(self):
+        self.send_response(200, "ok")
+        if (self.allowCORS):
+            self.send_header('Access-Control-Allow-Origin', self.headers.dict['origin'])
+            self.send_header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')        
+            self.send_header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
 
     def do_GET(self):        
         (uri, args, type) = self.process_uri("GET")
@@ -277,6 +284,7 @@ def main():
                 MongoHTTPRequest.mongos = a.split(',')
             if o == "-x" or o == "--xorigin":
                 MongoHTTPRequest.response_headers.append(("Access-Control-Allow-Origin","*"))
+                MongoHTTPRequest.allowCORS = True;
 
     except getopt.GetoptError:
         print "error parsing cmd line args."


### PR DESCRIPTION
Trying to access sleepy.mongoose (started with the `--xorigin` flag) from JavaScript with CORS on Chrome and Safari, I always got `501 Unsupported method ('OPTIONS')`. So I implemented it, works fine now.
